### PR TITLE
build: run structured pytest suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import tempfile
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolated_synopkg_pkgvar(monkeypatch):
+    """Keep runtime-state writes isolated between tests.
+
+    The package stores progress and findings below SYNOPKG_PKGVAR. Build runs
+    provide a temporary package var, but a single shared directory still allows
+    one test's persisted stop/progress state to influence later tests. Give each
+    test its own package var directory so tests cannot depend on execution
+    order or previously persisted runtime state.
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        monkeypatch.setenv("SYNOPKG_PKGVAR", tempdir)
+        yield

--- a/tools/build-package.sh
+++ b/tools/build-package.sh
@@ -58,7 +58,7 @@ TEST_PKGVAR="$(mktemp -d)"
 trap 'rm -rf "${TEST_PKGVAR}"' EXIT
 export SYNOPKG_PKGVAR="${TEST_PKGVAR}"
 
-PYTHONPATH=src python3 -m pytest tests/test_*.py
+PYTHONPATH=src python3 -m pytest tests
 
 log "Building Synology package"
 cd "${TOOLKIT_ROOT}"


### PR DESCRIPTION
## Summary
- run pytest against the structured tests directory instead of the removed flat tests/test_*.py pattern
- isolate SYNOPKG_PKGVAR per test to prevent persisted runtime-state leakage between tests

## Validation
- tools/build-package.sh -v 7.3 -c
- 385 passed, 1 skipped