### PR TITLE
Add secure worker enrollment and licensed model distribution

### DIFF
--- a/src/api/worker_api.py
+++ b/src/api/worker_api.py
@@ -6,14 +6,14 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import FileResponse, JSONResponse
 
 from services.config_service import ConfigService
 from services.worker_api_endpoints import handle_worker_api_request
-from services.worker_api_service import WorkerApiService
+from services.worker_api_service import WorkerApiError, WorkerApiService
+from services.worker_provisioning_service import WorkerProvisioningService
 
 router = APIRouter(prefix="/worker-api")
-
 _POST_ACTIONS = {"register", "heartbeat", "claim", "result", "fail"}
 _TRUE_VALUES = {"1", "true", "yes", "on"}
 _FALSE_VALUES = {"0", "false", "no", "off"}
@@ -49,8 +49,7 @@ def _worker_api_enabled() -> bool:
     override = _env_enabled_override()
     if override is not None:
         return override
-    config = _worker_api_config()
-    return bool(config.get("ENABLED", False))
+    return bool(_worker_api_config().get("ENABLED", False))
 
 
 def _resolve_package_var_path(value: str) -> Optional[Path]:
@@ -58,9 +57,7 @@ def _resolve_package_var_path(value: str) -> Optional[Path]:
     if not configured:
         return None
     path = Path(configured)
-    if path.is_absolute():
-        return path
-    return _package_var() / path
+    return path if path.is_absolute() else _package_var() / path
 
 
 def _worker_api_state_path() -> Optional[Path]:
@@ -86,12 +83,71 @@ def _disabled_response() -> JSONResponse:
     return JSONResponse(status_code=404, content={"status": "error", "code": "worker_api_disabled"})
 
 
+def _bearer(request: Request) -> str:
+    value = str(request.headers.get("authorization") or "").strip()
+    return value[7:].strip() if value.lower().startswith("bearer ") else ""
+
+
+def _worker_id(request: Request) -> str:
+    return str(request.headers.get("x-worker-id") or "").strip()
+
+
+def _error_response(exc: WorkerApiError) -> JSONResponse:
+    code = exc.code
+    status = 401 if code in {"unauthorized", "token_required"} else 403
+    if code.endswith("_not_found") or code == "model_file_not_allowed":
+        status = 404
+    if code.startswith("invalid_") or code.endswith("_required"):
+        status = 400
+    return JSONResponse(status_code=status, content={"status": "error", "code": code, "message": str(exc)})
+
+
 @router.get("/status")
 async def status() -> JSONResponse:
     if not _worker_api_enabled():
         return _disabled_response()
     service = WorkerApiService(package_var=_package_var(), state_path=_worker_api_state_path())
     return JSONResponse(status_code=200, content={"status": "ok", "service": service.status()})
+
+
+@router.post("/enroll")
+async def enroll(request: Request) -> JSONResponse:
+    if not _worker_api_enabled():
+        return _disabled_response()
+    body = await _json_body(request)
+    service = WorkerProvisioningService(package_var=_package_var(), state_path=_worker_api_state_path())
+    try:
+        payload = service.redeem_enrollment(
+            enrollment_code=str(body.get("enrollment_code") or ""),
+            worker_id=str(body.get("worker_id") or ""),
+        )
+        return JSONResponse(status_code=200, content=payload)
+    except WorkerApiError as exc:
+        return _error_response(exc)
+
+
+@router.get("/models/{model_pack}/manifest")
+async def model_manifest(model_pack: str, request: Request) -> JSONResponse:
+    if not _worker_api_enabled():
+        return _disabled_response()
+    service = WorkerProvisioningService(package_var=_package_var(), state_path=_worker_api_state_path())
+    try:
+        payload = service.model_manifest(token=_bearer(request), worker_id=_worker_id(request), model_pack=model_pack)
+        return JSONResponse(status_code=200, content=payload)
+    except WorkerApiError as exc:
+        return _error_response(exc)
+
+
+@router.get("/models/{model_pack}/files/{filename}")
+async def model_file(model_pack: str, filename: str, request: Request):
+    if not _worker_api_enabled():
+        return _disabled_response()
+    service = WorkerProvisioningService(package_var=_package_var(), state_path=_worker_api_state_path())
+    try:
+        path = service.model_file(token=_bearer(request), worker_id=_worker_id(request), model_pack=model_pack, filename=filename)
+        return FileResponse(path=str(path), media_type="application/octet-stream", filename=filename)
+    except WorkerApiError as exc:
+        return _error_response(exc)
 
 
 @router.post("/{action}")

--- a/src/services/worker_provisioning_service.py
+++ b/src/services/worker_provisioning_service.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Secure external-worker enrollment and licensed model distribution."""
+
+import hashlib
+import json
+import os
+import secrets
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+from services.config_service import ConfigService
+from services.face_model_store_service import FaceModelStoreService
+from services.worker_api_service import WorkerApiError
+
+
+class WorkerProvisioningService:
+    DEFAULT_SCOPES = ("worker_api", "models_read")
+
+    def __init__(self, *, package_var: Optional[Path] = None, state_path: Optional[Path] = None,
+                 clock: Optional[Callable[[], datetime]] = None):
+        self.package_var = Path(package_var) if package_var else Path(os.getenv("SYNOPKG_PKGVAR", "/var/packages/AV_ImgData/var"))
+        self.state_path = Path(state_path) if state_path else self.package_var / "worker-api-state.json"
+        self._clock = clock if callable(clock) else lambda: datetime.now(timezone.utc)
+
+    def create_enrollment(self, *, enrollment_id: str, expires_minutes: int = 15) -> Dict[str, Any]:
+        enrollment_id = self._required(enrollment_id, "enrollment_id_required")
+        expires_minutes = max(1, min(int(expires_minutes), 1440))
+        code = secrets.token_urlsafe(24)
+        state = self._read_state()
+        entry = {
+            "code_hash": self._hash(code),
+            "created_at": self._iso(self._now()),
+            "expires_at": self._iso(self._now() + timedelta(minutes=expires_minutes)),
+            "used_at": None,
+            "worker_id": None,
+        }
+        state.setdefault("enrollments", {})[enrollment_id] = entry
+        self._write_state(state)
+        return {"enrollment_id": enrollment_id, "enrollment_code": code, "expires_at": entry["expires_at"]}
+
+    def redeem_enrollment(self, *, enrollment_code: str, worker_id: str) -> Dict[str, Any]:
+        enrollment_code = self._required(enrollment_code, "enrollment_code_required")
+        worker_id = self._required(worker_id, "worker_id_required")
+        state = self._read_state()
+        digest = self._hash(enrollment_code)
+        match_id = None
+        match = None
+        for enrollment_id, entry in state.setdefault("enrollments", {}).items():
+            if entry.get("code_hash") == digest:
+                match_id, match = enrollment_id, entry
+                break
+        if match is None:
+            raise WorkerApiError("invalid_enrollment_code")
+        if match.get("used_at"):
+            raise WorkerApiError("enrollment_code_used")
+        if self._parse_iso(match.get("expires_at")) <= self._now():
+            raise WorkerApiError("enrollment_code_expired")
+
+        token = secrets.token_urlsafe(32)
+        token_id = "worker-%s-%s" % (worker_id, secrets.token_hex(4))
+        now = self._iso(self._now())
+        state.setdefault("tokens", {})[token_id] = {
+            "token_hash": self._hash(token),
+            "created_at": now,
+            "revoked": False,
+            "worker_id": worker_id,
+            "scopes": list(self.DEFAULT_SCOPES),
+            "issued_via": "enrollment",
+            "enrollment_id": match_id,
+        }
+        match["used_at"] = now
+        match["worker_id"] = worker_id
+        self._write_state(state)
+        return {"status": "enrolled", "worker_id": worker_id, "token_id": token_id, "token": token,
+                "scopes": list(self.DEFAULT_SCOPES)}
+
+    def require_token(self, *, token: str, worker_id: str, scope: str) -> Dict[str, Any]:
+        token = self._required(token, "token_required")
+        worker_id = self._required(worker_id, "worker_id_required")
+        digest = self._hash(token)
+        state = self._read_state()
+        for token_id, entry in state.get("tokens", {}).items():
+            if entry.get("token_hash") != digest or entry.get("revoked"):
+                continue
+            bound_worker = str(entry.get("worker_id") or "").strip()
+            if bound_worker and bound_worker != worker_id:
+                raise WorkerApiError("token_worker_mismatch")
+            scopes = entry.get("scopes") if isinstance(entry.get("scopes"), list) else ["worker_api", "models_read"]
+            if scope not in scopes:
+                raise WorkerApiError("token_scope_missing")
+            return {"token_id": token_id, "worker_id": bound_worker or worker_id, "scopes": scopes}
+        raise WorkerApiError("unauthorized")
+
+    def model_manifest(self, *, token: str, worker_id: str, model_pack: str = "buffalo_l") -> Dict[str, Any]:
+        self.require_token(token=token, worker_id=worker_id, scope="models_read")
+        store = self._model_store()
+        status = store.status(model_pack)
+        if not status.get("license_ack_present"):
+            raise WorkerApiError("model_license_not_acknowledged")
+        if not status.get("models_present"):
+            raise WorkerApiError("model_files_missing")
+        manifest_path = Path(status["manifest_path"])
+        if not manifest_path.is_file():
+            store.write_manifest(model_pack=model_pack, source="worker_distribution")
+        with manifest_path.open("r", encoding="utf-8") as handle:
+            manifest = json.load(handle)
+        manifest["download_base"] = "/worker-api/models/%s/files" % model_pack
+        manifest["license_acknowledged"] = True
+        return manifest
+
+    def model_file(self, *, token: str, worker_id: str, model_pack: str, filename: str) -> Path:
+        manifest = self.model_manifest(token=token, worker_id=worker_id, model_pack=model_pack)
+        allowed = {str(item.get("name")) for item in manifest.get("files", []) if item.get("present")}
+        if filename not in allowed:
+            raise WorkerApiError("model_file_not_allowed")
+        path = self._model_store().model_dir(model_pack) / filename
+        if not path.is_file():
+            raise WorkerApiError("model_file_not_found")
+        return path
+
+    def _model_store(self) -> FaceModelStoreService:
+        return FaceModelStoreService(ConfigService(str(self.package_var / "config.json")), package_var=self.package_var)
+
+    def _read_state(self) -> Dict[str, Any]:
+        if not self.state_path.is_file():
+            return {"schema_version": 2, "tokens": {}, "workers": {}, "jobs": {}, "enrollments": {}}
+        with self.state_path.open("r", encoding="utf-8") as handle:
+            state = json.load(handle)
+        if not isinstance(state, dict):
+            raise WorkerApiError("state_invalid")
+        state.setdefault("tokens", {})
+        state.setdefault("workers", {})
+        state.setdefault("jobs", {})
+        state.setdefault("enrollments", {})
+        state["schema_version"] = max(2, int(state.get("schema_version", 1)))
+        return state
+
+    def _write_state(self, state: Dict[str, Any]) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=self.state_path.name + ".", suffix=".tmp", dir=str(self.state_path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(state, handle, ensure_ascii=False, indent=2, sort_keys=True)
+                handle.write("\n")
+            os.replace(tmp, str(self.state_path))
+        finally:
+            try:
+                os.unlink(tmp)
+            except FileNotFoundError:
+                pass
+
+    def _now(self) -> datetime:
+        value = self._clock()
+        return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value.astimezone(timezone.utc)
+
+    @staticmethod
+    def _iso(value: datetime) -> str:
+        return value.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    @staticmethod
+    def _parse_iso(value: Any) -> datetime:
+        try:
+            return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
+        except Exception:
+            return datetime.fromtimestamp(0, tz=timezone.utc)
+
+    @staticmethod
+    def _hash(value: str) -> str:
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+    @staticmethod
+    def _required(value: Any, code: str) -> str:
+        text = str(value or "").strip()
+        if not text:
+            raise WorkerApiError(code)
+        return text

--- a/tests/unit/services/test_worker_provisioning_service.py
+++ b/tests/unit/services/test_worker_provisioning_service.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from services.worker_api_service import WorkerApiError
+from services.worker_provisioning_service import WorkerProvisioningService
+
+
+UTC = timezone.utc
+
+
+def test_enrollment_is_one_time_and_worker_bound(tmp_path):
+    now = datetime(2026, 7, 10, 12, 0, tzinfo=UTC)
+    service = WorkerProvisioningService(package_var=tmp_path, clock=lambda: now)
+    created = service.create_enrollment(enrollment_id="windows-01", expires_minutes=15)
+    enrolled = service.redeem_enrollment(enrollment_code=created["enrollment_code"], worker_id="worker-01")
+
+    auth = service.require_token(token=enrolled["token"], worker_id="worker-01", scope="models_read")
+    assert auth["worker_id"] == "worker-01"
+
+    with pytest.raises(WorkerApiError, match="token_worker_mismatch"):
+        service.require_token(token=enrolled["token"], worker_id="worker-02", scope="models_read")
+
+    with pytest.raises(WorkerApiError, match="enrollment_code_used"):
+        service.redeem_enrollment(enrollment_code=created["enrollment_code"], worker_id="worker-01")
+
+
+def test_expired_enrollment_is_rejected(tmp_path):
+    current = [datetime(2026, 7, 10, 12, 0, tzinfo=UTC)]
+    service = WorkerProvisioningService(package_var=tmp_path, clock=lambda: current[0])
+    created = service.create_enrollment(enrollment_id="windows-01", expires_minutes=1)
+    current[0] += timedelta(minutes=2)
+
+    with pytest.raises(WorkerApiError, match="enrollment_code_expired"):
+        service.redeem_enrollment(enrollment_code=created["enrollment_code"], worker_id="worker-01")

--- a/tools/create-worker-enrollment.py
+++ b/tools/create-worker-enrollment.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Create a short-lived, one-time external-worker enrollment code."""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+PROJECT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_DIR / "src"))
+
+from services.worker_provisioning_service import WorkerProvisioningService
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package-var", default=os.getenv("SYNOPKG_PKGVAR", "/var/packages/AV_ImgData/var"))
+    parser.add_argument("--state-path", default=os.getenv("AV_IMGDATA_WORKER_API_STATE_PATH", ""))
+    parser.add_argument("--enrollment-id", required=True)
+    parser.add_argument("--expires-minutes", type=int, default=15)
+    args = parser.parse_args()
+
+    package_var = Path(args.package_var)
+    state_path = Path(args.state_path) if args.state_path else package_var / "worker-api-state.json"
+    if not state_path.is_absolute():
+        state_path = package_var / state_path
+    service = WorkerProvisioningService(package_var=package_var, state_path=state_path)
+    payload = service.create_enrollment(enrollment_id=args.enrollment_id, expires_minutes=args.expires_minutes)
+    print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/worker/CMakeLists.txt
+++ b/worker/CMakeLists.txt
@@ -28,8 +28,6 @@ target_compile_definitions(av-imgdata-worker-api-loop PRIVATE
 )
 
 if(MINGW)
-  # Keep the Windows worker executables runnable on a plain Windows 11 host
-  # without requiring MinGW runtime DLLs next to the .exe.
   target_link_options(av-imgdata-worker PRIVATE
     -static-libgcc
     -static-libstdc++
@@ -49,3 +47,6 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/../processor_contract/schemas/face-native-j
 endif()
 
 install(DIRECTORY packaging/ DESTINATION packaging)
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/packaging/windows/Initialize-AVImgDataWorker.ps1")
+  install(FILES packaging/windows/Initialize-AVImgDataWorker.ps1 DESTINATION .)
+endif()

--- a/worker/packaging/windows/Initialize-AVImgDataWorker.ps1
+++ b/worker/packaging/windows/Initialize-AVImgDataWorker.ps1
@@ -1,0 +1,64 @@
+param(
+  [Parameter(Mandatory=$true)][string]$ApiUrl,
+  [Parameter(Mandatory=$true)][string]$EnrollmentCode,
+  [Parameter(Mandatory=$true)][string]$WorkerId,
+  [Parameter(Mandatory=$true)][string]$PathBaseDir,
+  [string]$ModelPack = "buffalo_l",
+  [string]$ConfigPath = "$PSScriptRoot\..\..\config\worker-config.example.json"
+)
+
+$ErrorActionPreference = "Stop"
+$ApiUrl = $ApiUrl.TrimEnd('/')
+$BundleRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\.."))
+$ConfigPath = [System.IO.Path]::GetFullPath($ConfigPath)
+$TokenPath = Join-Path $BundleRoot "worker.token"
+$ModelRoot = Join-Path $BundleRoot ".models\face"
+$ModelDir = Join-Path $ModelRoot $ModelPack
+
+Write-Host "Enrolling worker '$WorkerId' against $ApiUrl"
+$enrollment = Invoke-RestMethod -Method Post -Uri "$ApiUrl/enroll" -ContentType "application/json" -Body (@{
+  enrollment_code = $EnrollmentCode
+  worker_id = $WorkerId
+} | ConvertTo-Json)
+
+if (-not $enrollment.token) { throw "Enrollment response did not contain a token." }
+[System.IO.File]::WriteAllText($TokenPath, [string]$enrollment.token, [System.Text.UTF8Encoding]::new($false))
+
+# Restrict token file to the current Windows account.
+& icacls.exe $TokenPath /inheritance:r /grant:r "$env:USERNAME:(R,W)" | Out-Null
+
+$headers = @{
+  Authorization = "Bearer $($enrollment.token)"
+  "X-Worker-Id" = $WorkerId
+}
+$manifest = Invoke-RestMethod -Method Get -Uri "$ApiUrl/models/$ModelPack/manifest" -Headers $headers
+New-Item -ItemType Directory -Force -Path $ModelDir | Out-Null
+
+foreach ($file in $manifest.files) {
+  if (-not $file.present) { continue }
+  $target = Join-Path $ModelDir $file.name
+  $temp = "$target.download"
+  Invoke-WebRequest -UseBasicParsing -Uri "$ApiUrl/models/$ModelPack/files/$($file.name)" -Headers $headers -OutFile $temp
+  $actual = (Get-FileHash -Algorithm SHA256 -Path $temp).Hash.ToLowerInvariant()
+  $expected = ([string]$file.sha256).ToLowerInvariant()
+  if ($actual -ne $expected) {
+    Remove-Item -Force $temp -ErrorAction SilentlyContinue
+    throw "SHA-256 mismatch for $($file.name): expected $expected, got $actual"
+  }
+  Move-Item -Force $temp $target
+}
+$manifest | ConvertTo-Json -Depth 10 | Set-Content -Encoding UTF8 (Join-Path $ModelDir "manifest.json")
+
+$config = Get-Content -Raw -Encoding UTF8 $ConfigPath | ConvertFrom-Json
+$config.worker_id = $WorkerId
+$config.worker_api_base_url = $ApiUrl
+$config.path_base_dir = $PathBaseDir
+$config.auth.token_file = "../worker.token"
+$config.processors.face.model_root = "../.models/face"
+$config.processors.face.model_name = $ModelPack
+$config | ConvertTo-Json -Depth 20 | Set-Content -Encoding UTF8 $ConfigPath
+
+Write-Host "Worker enrolled and model files synchronized."
+Write-Host "Config: $ConfigPath"
+Write-Host "Token:  $TokenPath"
+Write-Host "Models: $ModelDir"


### PR DESCRIPTION
## Summary
- add short-lived, one-time worker enrollment codes
- issue worker-bound tokens with explicit `worker_api` and `models_read` scopes
- expose authenticated model manifest and model file endpoints
- require NAS-side model presence and license acknowledgement before distribution
- add a Windows bootstrap script that redeems the enrollment code, stores the token with restricted ACLs, downloads model files, verifies SHA-256, and updates worker config
- bundle the bootstrap script with generated worker artifacts
- add unit coverage for one-time enrollment, expiry, and worker binding

## Admin flow
1. Create enrollment code on DSM:
   `sudo python3 /var/packages/AV_ImgData/target/tools/create-worker-enrollment.py --enrollment-id windows-worker-01`
2. Run `Initialize-AVImgDataWorker.ps1` in the downloaded Windows bundle with API URL, code, worker ID, and shared path.
3. The script writes `worker.token`, synchronizes only licensed NAS models, verifies hashes, and updates config.

## Security properties
- enrollment codes expire and can be redeemed once
- issued tokens are bound to one worker ID
- model endpoints require `models_read`
- model distribution is blocked until `LICENSE_ACK.json` and required model files exist
- the worker verifies every downloaded model file against the NAS manifest SHA-256

## Validation
- added unit tests for enrollment reuse, expiry, and worker/token mismatch
- branch is 6 commits ahead of `main` and touches only provisioning/API/packaging files